### PR TITLE
Revert "Fix typo (#13)"

### DIFF
--- a/threading-doc/scribblings/threading.scrbl
+++ b/threading-doc/scribblings/threading.scrbl
@@ -328,7 +328,7 @@ Like @racket[lambda~>], but uses @racket[~>>] instead of @racket[~>].}
 
 @deftogether[(@defform[(lambda~>* clause ...)]
               @defform[(λ~>* clause ...)])]{
-Equivalent to @racket[(λ args (~>* args clause ...))].
+Equivalent to @racket[(λ args (~> args clause ...))].
 
 @(examples
   #:eval (threading-eval)


### PR DESCRIPTION
Found a small typo in the documentation when using the `threading` library.
Thank you for creating this library!

---

This reverts commit 13a34f14fe073c328e5cc083c616a602a79afa58.

Didn't see any definition of `~>*` and it appears `lambda~>*` is implemented in
terms of `~>`.

```
~/pro/racket/threading $ grep -r '\B~>\*\B'
threading-doc/scribblings/threading.scrbl:Equivalent to @racket[(λ args (~>* args clause ...))].
```